### PR TITLE
Add client-side image filter demo

### DIFF
--- a/filter.css
+++ b/filter.css
@@ -1,0 +1,26 @@
+body {
+    font-family: Arial, sans-serif;
+    padding: 20px;
+    background: #f4f4f4;
+}
+#previewContainer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-top: 20px;
+}
+.preview {
+    position: relative;
+    border: 1px solid #ccc;
+    background: #fff;
+    padding: 10px;
+}
+.preview canvas {
+    display: block;
+    max-width: 100%;
+    height: auto;
+}
+.preview a {
+    display: inline-block;
+    margin-top: 5px;
+}

--- a/filter.html
+++ b/filter.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Filter App</title>
+    <link rel="stylesheet" href="filter.css">
+</head>
+<body>
+    <h1>Image Filter Demo</h1>
+    <input type="file" id="imageInput" accept="image/*" multiple>
+    <label for="filterSelect">Choose filter:</label>
+    <select id="filterSelect">
+        <option value="none">None</option>
+        <option value="grayscale(100%)">Grayscale</option>
+        <option value="sepia(100%)">Sepia</option>
+        <option value="invert(100%)">Invert</option>
+        <option value="brightness(150%)">Brightness +50%</option>
+        <option value="contrast(150%)">Contrast +50%</option>
+        <option value="blur(5px)">Blur</option>
+    </select>
+    <div id="previewContainer"></div>
+
+    <script src="filter.js"></script>
+</body>
+</html>

--- a/filter.js
+++ b/filter.js
@@ -1,0 +1,49 @@
+const imageInput = document.getElementById('imageInput');
+const filterSelect = document.getElementById('filterSelect');
+const previewContainer = document.getElementById('previewContainer');
+
+function applyFilterAndRender(file, filter) {
+    const reader = new FileReader();
+    reader.onload = function (e) {
+        const img = new Image();
+        img.onload = function () {
+            const canvas = document.createElement('canvas');
+            canvas.width = img.width;
+            canvas.height = img.height;
+            const ctx = canvas.getContext('2d');
+            ctx.filter = filter;
+            ctx.drawImage(img, 0, 0);
+
+            const preview = document.createElement('div');
+            preview.className = 'preview';
+            preview.appendChild(canvas);
+
+            const link = document.createElement('a');
+            link.textContent = 'Download';
+            link.download = file.name;
+            link.href = canvas.toDataURL('image/png');
+            preview.appendChild(link);
+
+            previewContainer.appendChild(preview);
+        };
+        img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+}
+
+imageInput.addEventListener('change', () => {
+    previewContainer.innerHTML = '';
+    const files = Array.from(imageInput.files);
+    const filterValue = filterSelect.value;
+    files.forEach(file => applyFilterAndRender(file, filterValue));
+});
+
+filterSelect.addEventListener('change', () => {
+    if (imageInput.files.length > 0) {
+        // Reapply filter to existing images
+        const files = Array.from(imageInput.files);
+        previewContainer.innerHTML = '';
+        const filterValue = filterSelect.value;
+        files.forEach(file => applyFilterAndRender(file, filterValue));
+    }
+});


### PR DESCRIPTION
## Summary
- create `filter.html` for a simple image filter web app
- style with `filter.css`
- implement filtering and download via `filter.js`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68655949ad208320876c18c4f734f9a4