### PR TITLE
Enhance client-side filters with Material look

### DIFF
--- a/filter.css
+++ b/filter.css
@@ -1,0 +1,30 @@
+body {
+    font-family: "Roboto", Arial, sans-serif;
+    background: #fafafa;
+    padding: 20px;
+}
+
+#previewContainer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin-top: 20px;
+}
+
+.preview {
+    padding: 10px;
+    background: #fff;
+    border-radius: 4px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+}
+
+.preview canvas {
+    display: block;
+    max-width: 100%;
+    height: auto;
+}
+
+.preview a {
+    display: inline-block;
+    margin-top: 8px;
+}

--- a/filter.html
+++ b/filter.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Image Filter App</title>
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/css/materialize.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="filter.css">
+</head>
+<body>
+    <div class="container">
+        <h3 class="center-align">Image Filter Demo</h3>
+        <div class="file-field input-field">
+            <div class="btn">
+                <span>Upload</span>
+                <input type="file" id="imageInput" accept="image/*" multiple>
+            </div>
+            <div class="file-path-wrapper">
+                <input class="file-path validate" type="text" placeholder="Upload one or more images">
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="input-field col s12 m6">
+                <p class="range-field">
+                    <label for="brightness">Brightness <span id="brightnessVal">100</span>%</label>
+                    <input type="range" id="brightness" min="0" max="200" value="100">
+                </p>
+            </div>
+            <div class="input-field col s12 m6">
+                <p class="range-field">
+                    <label for="contrast">Contrast <span id="contrastVal">100</span>%</label>
+                    <input type="range" id="contrast" min="0" max="200" value="100">
+                </p>
+            </div>
+            <div class="input-field col s12 m6">
+                <p class="range-field">
+                    <label for="saturate">Saturate <span id="saturateVal">100</span>%</label>
+                    <input type="range" id="saturate" min="0" max="200" value="100">
+                </p>
+            </div>
+            <div class="input-field col s12 m6">
+                <p class="range-field">
+                    <label for="grayscale">Grayscale <span id="grayscaleVal">0</span>%</label>
+                    <input type="range" id="grayscale" min="0" max="100" value="0">
+                </p>
+            </div>
+            <div class="input-field col s12 m6">
+                <p class="range-field">
+                    <label for="sepia">Sepia <span id="sepiaVal">0</span>%</label>
+                    <input type="range" id="sepia" min="0" max="100" value="0">
+                </p>
+            </div>
+            <div class="input-field col s12 m6">
+                <p class="range-field">
+                    <label for="hue">Hue Rotate <span id="hueVal">0</span>°</label>
+                    <input type="range" id="hue" min="0" max="360" value="0">
+                </p>
+            </div>
+            <div class="input-field col s12 m6">
+                <p class="range-field">
+                    <label for="blur">Blur <span id="blurVal">0</span>px</label>
+                    <input type="range" id="blur" min="0" max="10" value="0" step="0.5">
+                </p>
+            </div>
+        </div>
+
+        <div class="center-align">
+            <button id="applyButton" class="btn waves-effect waves-light">Apply Filters</button>
+        </div>
+
+        <div id="previewContainer" class="row"></div>
+    </div>
+
+    <script src="filter.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js"></script>
+</body>
+</html>

--- a/filter.js
+++ b/filter.js
@@ -1,0 +1,64 @@
+const imageInput = document.getElementById('imageInput');
+const previewContainer = document.getElementById('previewContainer');
+const applyButton = document.getElementById('applyButton');
+
+const controls = ['brightness', 'contrast', 'saturate', 'grayscale', 'sepia', 'hue', 'blur'];
+const inputs = {};
+controls.forEach(id => {
+    inputs[id] = document.getElementById(id);
+});
+
+function getFilter() {
+    return `brightness(${inputs.brightness.value}% ) ` +
+           `contrast(${inputs.contrast.value}% ) ` +
+           `saturate(${inputs.saturate.value}% ) ` +
+           `grayscale(${inputs.grayscale.value}% ) ` +
+           `sepia(${inputs.sepia.value}% ) ` +
+           `hue-rotate(${inputs.hue.value}deg) ` +
+           `blur(${inputs.blur.value}px)`;
+}
+
+function applyFilterAndRender(file, filter) {
+    const reader = new FileReader();
+    reader.onload = function (e) {
+        const img = new Image();
+        img.onload = function () {
+            const canvas = document.createElement('canvas');
+            canvas.width = img.width;
+            canvas.height = img.height;
+            const ctx = canvas.getContext('2d');
+            ctx.filter = filter;
+            ctx.drawImage(img, 0, 0);
+
+            const preview = document.createElement('div');
+            preview.className = 'preview';
+            preview.appendChild(canvas);
+
+            const link = document.createElement('a');
+            link.textContent = 'Download';
+            link.download = file.name;
+            link.href = canvas.toDataURL('image/png');
+            preview.appendChild(link);
+
+            previewContainer.appendChild(preview);
+        };
+        img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+}
+
+function applyFilters() {
+    previewContainer.innerHTML = '';
+    const files = Array.from(imageInput.files);
+    const filterValue = getFilter();
+    files.forEach(file => applyFilterAndRender(file, filterValue));
+}
+
+imageInput.addEventListener('change', applyFilters);
+applyButton.addEventListener('click', applyFilters);
+
+controls.forEach(id => {
+    inputs[id].addEventListener('input', () => {
+        document.getElementById(id + 'Val').textContent = inputs[id].value;
+    });
+});


### PR DESCRIPTION
## Summary
- revamp `filter.html` with Material design styling
- add adjustable filter sliders for brightness, contrast, saturation and more
- compute filter string from slider values in `filter.js`
- polish layout in `filter.css`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`
- `make test` *(fails: No rule to make target `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68655949ad208320876c18c4f734f9a4